### PR TITLE
Rename the role claim's name

### DIFF
--- a/Core/Services/JwtService.cs
+++ b/Core/Services/JwtService.cs
@@ -72,7 +72,7 @@ namespace Core.Services
             {
                 new Claim(ClaimTypes.NameIdentifier, user.Id),
                 new Claim(ClaimTypes.Email, user.Email),
-                new Claim(ClaimTypes.Role, userRole)
+                new Claim("role", userRole)
             };
 
             return claims;


### PR DESCRIPTION
> Without this, we can't get the value of the role on frontend, because the name ClaimTypes.Role is in reference format
>
![unknown](https://user-images.githubusercontent.com/56841893/167939937-be852688-6146-4748-afa7-92df5244115a.png)
t